### PR TITLE
Fix compression source and code generation

### DIFF
--- a/StringZipInputStream.java
+++ b/StringZipInputStream.java
@@ -97,22 +97,22 @@ final class StringZipInputStream implements java.io.Serializable {
 		return vector;
 	}
 	// A method to generate relative codes
-	private static Map<Character, String> generateCodes(Set<Character> chars, 
-			NodeH node) {
-		final Map<Character, String> map = new HashMap<Character, String>();
-		doGenerateCode(node, charCode, "");
-		return map;
-	}
+        private static Map<Character, String> generateCodes(Set<Character> chars,
+                        NodeH node) {
+                final Map<Character, String> map = new HashMap<Character, String>();
+                doGenerateCode(node, map, "");
+                return map;
+        }
 
-	private static void doGenerateCode(NodeH node, Map<Character, String> map,
-			String s) {
-		if (node.left == null && node.right == null) {
-			charCode.put(node.ch, s);
-			return;
-		}
-		doGenerateCode(node.left, charCode, s + '0');
-		doGenerateCode(node.right, charCode, s + '1');
-	}
+        private static void doGenerateCode(NodeH node, Map<Character, String> map,
+                        String s) {
+                if (node.left == null && node.right == null) {
+                        map.put(node.ch, s);
+                        return;
+                }
+                doGenerateCode(node.left, map, s + '0');
+                doGenerateCode(node.right, map, s + '1');
+        }
 
 	// A method to encode the messsage
 	private static String encodeMessage(Map<Character, String> charCode, 

--- a/StringZipOutputStream.java
+++ b/StringZipOutputStream.java
@@ -98,22 +98,22 @@ final class StringZipOutputStream implements java.io.Serializable {
 		return vector;
 	}
 	// A method to generate relative codes
-	private static Map<Character, String> generateCodes(Set<Character> chars, 
-			NodeH node) {
-		final Map<Character, String> map = new HashMap<Character, String>();
-		doGenerateCode(node, charCode, "");
-		return map;
-	}
+        private static Map<Character, String> generateCodes(Set<Character> chars,
+                        NodeH node) {
+                final Map<Character, String> map = new HashMap<Character, String>();
+                doGenerateCode(node, map, "");
+                return map;
+        }
 
-	private static void doGenerateCode(NodeH node, Map<Character, String> map,
-			String s) {
-		if (node.left == null && node.right == null) {
-			charCode.put(node.ch, s);
-			return;
-		}
-		doGenerateCode(node.left, charCode, s + '0');
-		doGenerateCode(node.right, charCode, s + '1');
-	}
+        private static void doGenerateCode(NodeH node, Map<Character, String> map,
+                        String s) {
+                if (node.left == null && node.right == null) {
+                        map.put(node.ch, s);
+                        return;
+                }
+                doGenerateCode(node.left, map, s + '0');
+                doGenerateCode(node.right, map, s + '1');
+        }
 
 	// A method to encode the messsage
 	private static String encodeMessage(Map<Character, String> charCode, 
@@ -230,8 +230,8 @@ final class StringZipOutputStream implements java.io.Serializable {
 					freqMap.putAll(compressObject.getCharFrequency(line));
 				}
 				//Thread.sleep(10000);
-				StringZipOutputStream.compress();
-				bufferedReader = new BufferedReader(new FileReader("words.txt"));
+                                StringZipOutputStream.compress();
+                                bufferedReader = new BufferedReader(new FileReader(fileNameToCompress));
 				while ((line = bufferedReader.readLine()) != null) {
 					line = line + "\n";
 					encodedMessage.append(compressObject.encodeMessage(charCode, 


### PR DESCRIPTION
## Summary
- fix `StringZipOutputStream` so it reads from the selected file instead of a hard-coded name
- fix Huffman code generation in both stream classes

## Testing
- `javac *.java`
- `java MyCompressTest <<EOF
sample.txt
1
2
3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685465e60e148321ae1ecc920db20f30