### PR TITLE
Fix comment typos

### DIFF
--- a/StringZipInputStream.java
+++ b/StringZipInputStream.java
@@ -114,7 +114,7 @@ final class StringZipInputStream implements java.io.Serializable {
                 doGenerateCode(node.right, map, s + '1');
         }
 
-	// A method to encode the messsage
+        // A method to encode the message
 	private static String encodeMessage(Map<Character, String> charCode, 
 			String sentence) throws IOException {
 		final StringBuilder stringBuilder = new StringBuilder();
@@ -150,7 +150,7 @@ final class StringZipInputStream implements java.io.Serializable {
 		bitSet.set(i, true); 
 		return bitSet;
 	}
-	// A method to encode the messsage
+        // A method to encode the message
 	public boolean decodeMessage(Map<Character, String> charCode) throws 
 	IOException {
 		StringBuffer temp = new StringBuffer();

--- a/StringZipOutputStream.java
+++ b/StringZipOutputStream.java
@@ -115,7 +115,7 @@ final class StringZipOutputStream implements java.io.Serializable {
                 doGenerateCode(node.right, map, s + '1');
         }
 
-	// A method to encode the messsage
+        // A method to encode the message
 	private static String encodeMessage(Map<Character, String> charCode, 
 			String sentence) throws IOException {
 		final StringBuilder stringBuilder = new StringBuilder();
@@ -151,7 +151,7 @@ final class StringZipOutputStream implements java.io.Serializable {
 		bitSet.set(i, true); 
 		return bitSet;
 	}
-	// A method to encode the messsage
+        // A method to encode the message
 	public boolean decodeMessage(Map<Character, String> charCode) throws 
 	IOException {
 		StringBuffer temp = new StringBuffer();


### PR DESCRIPTION
## Summary
- fix misspellings of "message" in StringZipInputStream.java
- fix misspellings of "message" in StringZipOutputStream.java

## Testing
- `javac *.java`


------
https://chatgpt.com/codex/tasks/task_e_68546762a0b88321bdebae1cf4167e56