### PR TITLE
Fix decodeMessage comments

### DIFF
--- a/StringZipInputStream.java
+++ b/StringZipInputStream.java
@@ -150,9 +150,9 @@ final class StringZipInputStream implements java.io.Serializable {
 		bitSet.set(i, true); 
 		return bitSet;
 	}
-	// A method to encode the messsage
-	public boolean decodeMessage(Map<Character, String> charCode) throws 
-	IOException {
+        // Decode the message from the encoded file
+        public boolean decodeMessage(Map<Character, String> charCode) throws
+        IOException {
 		StringBuffer temp = new StringBuffer();
 
 		try {

--- a/StringZipInputStream.java
+++ b/StringZipInputStream.java
@@ -114,7 +114,7 @@ final class StringZipInputStream implements java.io.Serializable {
                 doGenerateCode(node.right, map, s + '1');
         }
 
-	// A method to encode the messsage
+        // A method to encode the message
 	private static String encodeMessage(Map<Character, String> charCode, 
 			String sentence) throws IOException {
 		final StringBuilder stringBuilder = new StringBuilder();
@@ -150,7 +150,7 @@ final class StringZipInputStream implements java.io.Serializable {
 		bitSet.set(i, true); 
 		return bitSet;
 	}
-        // Decode the message from the encoded file
+        // Decode the message from the encoded file.
         public boolean decodeMessage(Map<Character, String> charCode) throws
         IOException {
 		StringBuffer temp = new StringBuffer();

--- a/StringZipOutputStream.java
+++ b/StringZipOutputStream.java
@@ -115,7 +115,7 @@ final class StringZipOutputStream implements java.io.Serializable {
                 doGenerateCode(node.right, map, s + '1');
         }
 
-	// A method to encode the messsage
+        // A method to encode the message
 	private static String encodeMessage(Map<Character, String> charCode, 
 			String sentence) throws IOException {
 		final StringBuilder stringBuilder = new StringBuilder();
@@ -151,7 +151,7 @@ final class StringZipOutputStream implements java.io.Serializable {
 		bitSet.set(i, true); 
 		return bitSet;
 	}
-        // Decode the message from the encoded file
+        // Decode the message from the encoded file.
         public boolean decodeMessage(Map<Character, String> charCode) throws
         IOException {
 		StringBuffer temp = new StringBuffer();

--- a/StringZipOutputStream.java
+++ b/StringZipOutputStream.java
@@ -151,9 +151,9 @@ final class StringZipOutputStream implements java.io.Serializable {
 		bitSet.set(i, true); 
 		return bitSet;
 	}
-	// A method to encode the messsage
-	public boolean decodeMessage(Map<Character, String> charCode) throws 
-	IOException {
+        // Decode the message from the encoded file
+        public boolean decodeMessage(Map<Character, String> charCode) throws
+        IOException {
 		StringBuffer temp = new StringBuffer();
 
 		try {


### PR DESCRIPTION
## Summary
- correct the comment describing `decodeMessage` in input and output streams

## Testing
- `javac *.java`

------
https://chatgpt.com/codex/tasks/task_e_68546767b9f48321b774d82a0a570629